### PR TITLE
Make taxa recognized as R repository by GitHub Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+notes/* linguist-documentation


### PR DESCRIPTION
Hello @zachary-foster :wave:

Thanks for the great tool :) I hope more people are going to develop other tools using `taxa`.

## Description

When looking for R packages I matched `taxa` but realized it was tagged as HTML by GitHub's Linguist tool. This prevent to find the repo when using the `language:R` option in GitHub search.

The only HTML file found in the repo is in the `notes/` folder. I thus tagged it as documentation through the `.gitattributes` file.

BTW, I noticed the [`taxa2`](https://github.com/zachary-foster/taxa2) repository, is there a roadmap or a documentation that would explain the main (planned) differences with `taxa`?

Thanks!